### PR TITLE
golang format tools

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -35,7 +35,7 @@ import (
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/openzipkin/zipkin-go"
+	zipkin "github.com/openzipkin/zipkin-go"
 	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/openzipkin/zipkin-go"
+	zipkin "github.com/openzipkin/zipkin-go"
 	"github.com/pkg/errors"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats"

--- a/pkg/autoscaler/http_scrape_client.go
+++ b/pkg/autoscaler/http_scrape_client.go
@@ -68,7 +68,7 @@ func extractData(body io.Reader) (*Stat, error) {
 	for m, pv := range map[string]*float64{
 		"queue_average_concurrent_requests":         &stat.AverageConcurrentRequests,
 		"queue_average_proxied_concurrent_requests": &stat.AverageProxiedConcurrentRequests,
-		"queue_requests_per_second":               &stat.RequestCount,
+		"queue_requests_per_second":                 &stat.RequestCount,
 		"queue_proxied_operations_per_second":       &stat.ProxiedRequestCount,
 	} {
 		pm := prometheusMetric(metricFamilies, m)

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -19,19 +19,20 @@ package network
 import (
 	"context"
 	"fmt"
-	_ "knative.dev/pkg/system/testing"
-	"knative.dev/serving/pkg/network/prober"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	_ "knative.dev/pkg/system/testing"
+	"knative.dev/serving/pkg/network/prober"
 )
 
 func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 	body := "Inner Body"
-	cases := []struct{
-		name string
+	cases := []struct {
+		name    string
 		options []interface{}
-		want bool
+		want    bool
 	}{{
 		name: "successful probe when both headers are specified",
 		options: []interface{}{
@@ -39,7 +40,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 			prober.WithHeader(HashHeaderName, "foo-bar-baz"),
 		},
 		want: true,
-	},{
+	}, {
 		name: "forwards to inner handler when probe header is not specified",
 		options: []interface{}{
 			prober.WithHeader(HashHeaderName, "foo-bar-baz"),
@@ -48,7 +49,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 			prober.ExpectsHeader(HashHeaderName, "false"),
 		},
 		want: true,
-	},{
+	}, {
 		name: "forwards to inner handler when probe header is not 'probe'",
 		options: []interface{}{
 			prober.WithHeader(ProbeHeaderName, "queue"),
@@ -59,7 +60,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 			prober.ExpectsHeader(HashHeaderName, "false"),
 		},
 		want: true,
-	},{
+	}, {
 		name: "failed probe when hash header is not present",
 		options: []interface{}{
 			prober.WithHeader(ProbeHeaderName, ProbeHeaderValue),
@@ -67,7 +68,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 		want: false,
 	}}
 
-	var h  http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, ok := r.Header[ProbeHeaderName]
 		w.Header().Set(ProbeHeaderName, fmt.Sprintf("%t", ok))
 		_, ok = r.Header[HashHeaderName]


### PR DESCRIPTION
<!--golang format tools-->
<!--401b884b120eb74e9b73c37601540105-->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign JRBANCEL
